### PR TITLE
docs: Tiny change

### DIFF
--- a/src/content/ACM Development/Workshops/frontend-backend-workshop.mdx
+++ b/src/content/ACM Development/Workshops/frontend-backend-workshop.mdx
@@ -101,8 +101,8 @@ _(You should see `(.venv)` appear in your terminal prompt)._
 **4. Install Python packages:**
 
 ```bash
-pip install -r requirements.txt
 cd ..
+pip install -r requirements.txt
 ```
 
 ---


### PR DESCRIPTION
I just ran the steps back and I saw this tiny error. When installing the requirements.txt with no filepath BS, the user has to be in the root directory first, and the `cd ..` command was backwards with the install command